### PR TITLE
Retain the case of database objects (tables, columns, etc.) from the …

### DIFF
--- a/src/main/scala/com/github/daniel/shuy/liquibase/slick/codegen/SbtLiquibaseSlickCodegen.scala
+++ b/src/main/scala/com/github/daniel/shuy/liquibase/slick/codegen/SbtLiquibaseSlickCodegen.scala
@@ -169,7 +169,7 @@ object SbtLiquibaseSlickCodegen extends AutoPlugin {
         // create an embedded database with Auto Mixed Mode
         // (Server is required for Liquibase and Slick Codegen to share a database, as both do not share the same Class Loader)
         // persist database to a file (Auto Mixed Mode cannot be used with in-memory databases)
-        liquibaseUrl := s"jdbc:h2:file:${target.value.getPath}/$DbName;AUTO_SERVER=TRUE",
+        liquibaseUrl := s"jdbc:h2:file:${target.value.getPath}/$DbName;AUTO_SERVER=TRUE;DATABASE_TO_UPPER=FALSE",
 
         liquibaseUsername := Username,
         liquibasePassword := Password,


### PR DESCRIPTION
We ran into a problem using your liquibase-slick codegen plugin in our environment. The code generated referenced database object names (for tables, index, columns, etc) that were all upper case. This was fine for MySQL on OSX or Windows but our deployment targets are Linux and on that platform this didn't jive with the actual database names which for us are all lowercase (Linux MySQL is case sensitive by default). This happens because the intermediate H2 database that's used to drive the slick codegen uppercases all database object names by default. There is a connection option, DATABASE_TO_UPPER (default TRUE), that controls whether the case is retained rather than always uppercased in H2. Setting this setting to FALSE retains the case of the objects as specified in the Liquibase changelog which is what we were expecting to happen.

The H2 docs for that connection setting are http://www.h2database.com/javadoc/org/h2/engine/DbSettings.html#DATABASE_TO_UPPER

It's working for us with this change. We'd love for you to incorporate this into your plugin or to abstract out the H2 connection settings so this is easy to set/override in the plugin configuration.

Happy to discuss at your convenience.
