### PR TITLE
Update SBT to 1.3.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ addSbtPlugin("com.permutive" % "sbt-liquibase" % "1.1.0")
 
 crossSbtVersions := Seq(
   "0.13.17",
-  "1.2.6"
+  "1.3.2"
 )
 
 def slickVersion(scalaVersion: String) =

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.2.6
+sbt.version = 1.3.2

--- a/src/sbt-test/sbt-1.0/compile/project/build.properties
+++ b/src/sbt-test/sbt-1.0/compile/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.2.6
+sbt.version = 1.3.2

--- a/src/sbt-test/sbt-1.0/compile/project/plugins.sbt
+++ b/src/sbt-test/sbt-1.0/compile/project/plugins.sbt
@@ -4,5 +4,7 @@ sys.props.get("plugin.version") match {
                          |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
 }
 
+useCoursier := false
+
 addSbtPlugin("com.github.daniel-shuy" % "sbt-scripted-scalatest" % "1.1.1")
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.8"

--- a/src/sbt-test/sbt-1.0/liquibase-slick-codegen/project/build.properties
+++ b/src/sbt-test/sbt-1.0/liquibase-slick-codegen/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.2.6
+sbt.version = 1.3.2

--- a/src/sbt-test/sbt-1.0/liquibase-slick-codegen/project/plugins.sbt
+++ b/src/sbt-test/sbt-1.0/liquibase-slick-codegen/project/plugins.sbt
@@ -4,5 +4,7 @@ sys.props.get("plugin.version") match {
                          |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
 }
 
+useCoursier := false
+
 addSbtPlugin("com.github.daniel-shuy" % "sbt-scripted-scalatest" % "1.1.1")
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.8"


### PR DESCRIPTION
`useCoursier := false` is required in `scripted` tests due to issue with Coursier in SBT 1.3 (see sbt/sbt#5227)