### PR TITLE
Feature/renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,7 +3,6 @@
     "config:base",
   ],
   rebaseWhen: "behind-base-branch",
-  stabilityDays: 1,
   prCreation: "not-pending",
   dependencyDashboard: true,
   automerge: true,

--- a/renovate.json5
+++ b/renovate.json5
@@ -4,6 +4,7 @@
   ],
   rebaseWhen: "behind-base-branch",
   stabilityDays: 1,
+  prCreation: "not-pending",
   automerge: true,
   major: {
     automerge: false,

--- a/renovate.json5
+++ b/renovate.json5
@@ -25,7 +25,19 @@
       packageNames: [
         'com.permutive:sbt-liquibase',
       ],
+      updateTypes: [
+        'minor',
+      ],
       automerge: false,
+    },
+    {
+      packageNames: [
+        'com.permutive:sbt-liquibase',
+      ],
+      updateTypes: [
+        'patch',
+      ],
+      enabled: false,
     },
     {
       packageNames: [

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,8 +1,8 @@
 {
   extends: [
-    'config:base',
+    "config:base",
   ],
-  rebaseWhen: 'behind-base-branch',
+  rebaseWhen: "behind-base-branch",
   stabilityDays: 1,
   automerge: true,
   major: {
@@ -17,35 +17,35 @@
         TODO: Remove after https://github.com/scalatest/scalatest/issues/1766 is fixed
       */
       packageNames: [
-        'org.scalatest:scalatest',
+        "org.scalatest:scalatest",
       ],
-      versioning: 'semver',
+      versioning: "semver",
     },
     {
       packageNames: [
-        'com.permutive:sbt-liquibase',
+        "com.permutive:sbt-liquibase",
       ],
       updateTypes: [
-        'minor',
+        "minor",
       ],
       automerge: false,
     },
     {
       packageNames: [
-        'com.permutive:sbt-liquibase',
+        "com.permutive:sbt-liquibase",
       ],
       updateTypes: [
-        'patch',
+        "patch",
       ],
       enabled: false,
     },
     {
       packageNames: [
-        'org.scalameta:sbt-scalafmt',
+        "org.scalameta:sbt-scalafmt",
       ],
       automerge: false,
       prBodyNotes: [
-        ':warning: .scalafmt.conf must be updated manually',
+        ":warning: .scalafmt.conf must be updated manually",
       ],
     },
   ],

--- a/renovate.json5
+++ b/renovate.json5
@@ -19,7 +19,7 @@
       packageNames: [
         'org.scalatest:scalatest',
       ],
-      versionScheme: 'semver',
+      versioning: 'semver',
     },
     {
       packageNames: [

--- a/renovate.json5
+++ b/renovate.json5
@@ -2,7 +2,7 @@
   extends: [
     'config:base',
   ],
-  rebaseStalePrs: true,
+  rebaseWhen: 'behind-base-branch',
   stabilityDays: 1,
   automerge: true,
   major: {

--- a/renovate.json5
+++ b/renovate.json5
@@ -22,12 +22,19 @@
       versionScheme: 'semver',
     },
     {
-      // disable automerge for dependencies that require documentation update
       packageNames: [
-        'org.scalameta:sbt-scalafmt',
         'com.permutive:sbt-liquibase',
       ],
       automerge: false,
+    },
+    {
+      packageNames: [
+        'org.scalameta:sbt-scalafmt',
+      ],
+      automerge: false,
+      prBodyNotes: [
+        ':warning: .scalafmt.conf must be updated manually',
+      ],
     },
   ],
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -31,6 +31,9 @@
         "minor",
       ],
       automerge: false,
+      prBodyNotes: [
+        ":warning: README.md must be updated manually",
+      ],
     },
     {
       packageNames: [

--- a/renovate.json5
+++ b/renovate.json5
@@ -5,6 +5,7 @@
   rebaseWhen: "behind-base-branch",
   stabilityDays: 1,
   prCreation: "not-pending",
+  dependencyDashboard: true,
   automerge: true,
   major: {
     automerge: false,


### PR DESCRIPTION
Update Renovate configuration:
- Add Renovate [prBodyNotes](https://docs.renovatebot.com/configuration-options/#prbodynotes) for:
    - `org.scalameta:sbt-scalafmt`
    - `com.permutive:sbt-liquibase`
- Disable `patch` updates for `com.permutive:sbt-liquibase`
- Replace Renovate `versionScheme` with [versioning](https://docs.renovatebot.com/configuration-options/#versioning)
- Replace Renovate `rebaseStalePrs` with [rebaseWhen](https://docs.renovatebot.com/configuration-options/#rebasewhen)
- Use double quotes for strings in `renovate.json5`
- Change Renovate [prCreation](https://docs.renovatebot.com/configuration-options/#prcreation) to `not-pending`
- Enable Renovate [dependencyDashboard](https://docs.renovatebot.com/configuration-options/#dependencydashboard)
- Remove Renovate [stabilityDays](https://docs.renovatebot.com/configuration-options/#stabilitydays)