### PR TITLE
Update dependency com.h2database:h2 to v2.1.210

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,5 +49,5 @@ def slickVersion(scalaVersion: String) =
 
 libraryDependencies ++= Seq(
   "com.typesafe.slick" %% "slick-codegen" % slickVersion(scalaVersion.value),
-  "com.h2database" % "h2" % "1.4.200"
+  "com.h2database" % "h2" % "2.1.210"
 )


### PR DESCRIPTION
`com.h2database:h2` `1.x` has the following security vulnerabilities which have been fixed in `2.x`:
- [CVE-2021-23463](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23463)
- [CVE-2021-42392](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-42392)
- [CVE-2022-23221](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23221)